### PR TITLE
A simple solution

### DIFF
--- a/framework/include/base/BlockRestrictable.h
+++ b/framework/include/base/BlockRestrictable.h
@@ -154,10 +154,10 @@ public:
 
 private:
 
-  /// Set of block ids
+  /// Set of block ids supplied by the user via the input file
   std::set<SubdomainID> _blk_ids;
 
-  /// Vector the block names
+  /// Vector the block names supplied by the user via the input file
   std::vector<SubdomainName> _blocks;
 
   /// Flag for allowing dual restriction

--- a/framework/src/base/BlockRestrictable.C
+++ b/framework/src/base/BlockRestrictable.C
@@ -104,14 +104,7 @@ BlockRestrictable::BlockRestrictable(const std::string name, InputParameters & p
   if (_blk_ids.empty())
   {
     _blk_ids.insert(Moose::ANY_BLOCK_ID);
-    for (std::set<SubdomainID>::iterator it = _blk_mesh->meshSubdomains().begin();
-         it != _blk_mesh->meshSubdomains().end(); it++)
-    {
-      std::stringstream ss;
-      ss << *it;
-      _blocks.push_back(ss.str());
-      ss.str("");
-    }
+    _blocks = std::vector<SubdomainName>(1,"ANY_BLOCK_ID");
   }
 
   // Store the private parameter that contains the set of block ids

--- a/framework/src/base/BoundaryRestrictable.C
+++ b/framework/src/base/BoundaryRestrictable.C
@@ -74,14 +74,7 @@ BoundaryRestrictable::BoundaryRestrictable(const std::string name, InputParamete
   if (_bnd_ids.empty())
   {
     _bnd_ids.insert(Moose::ANY_BOUNDARY_ID);
-    for (std::set<BoundaryID>::iterator it = _bnd_mesh->meshBoundaryIds().begin();
-         it != _bnd_mesh->meshBoundaryIds().end(); it++)
-    {
-      std::stringstream ss;
-      ss << *it;
-      _boundary_names.push_back(ss.str());
-      ss.str("");
-    }
+    _boundary_names = std::vector<BoundaryName>(1,"ANY_BOUNDARY_ID");
   }
 
   // Store the ids in the input parameters


### PR DESCRIPTION
'ANY_BLOCK_ID' as a name should be handled correctly by MOOSE. Let me know if this works. On another note, why do you need the names? Generally, MOOSE utilizes the IDs internally.
(#2930)
