### PR TITLE
Implement bit flags for multiple exec flags

### DIFF
--- a/framework/include/base/Moose.h
+++ b/framework/include/base/Moose.h
@@ -55,18 +55,19 @@ class FEProblem;
 // Note: If this enum is changed, make sure to modify the local
 // function populateExecTypes in Moose.C.
 enum ExecFlagType {
+  EXEC_NONE              = 0x00,
   /// Object is evaluated only once at the beginning of the simulation
-  EXEC_INITIAL,
+  EXEC_INITIAL           = 0x01,
   /// Object is evaluated in every residual computation
-  EXEC_RESIDUAL,
+  EXEC_RESIDUAL          = 0x02,
   /// Object is evaluated in every jacobian computation
-  EXEC_JACOBIAN,
+  EXEC_JACOBIAN          = 0x04,
   /// Object is evaluated at the end of every time step
-  EXEC_TIMESTEP,
+  EXEC_TIMESTEP          = 0x08,
   /// Object is evaluated at the beginning of every time step
-  EXEC_TIMESTEP_BEGIN,
+  EXEC_TIMESTEP_BEGIN    = 0x10,
   /// For use with custom executioners that want to fire objects at a specific time
-  EXEC_CUSTOM
+  EXEC_CUSTOM            = 0x20
 };
 
 namespace Moose

--- a/framework/include/base/SetupInterface.h
+++ b/framework/include/base/SetupInterface.h
@@ -62,6 +62,11 @@ public:
   virtual const std::vector<ExecFlagType> & execFlags() const;
 
   /**
+   * Build and return the execution flags as a bitfield
+   */
+  ExecFlagType execBitFlags() const;
+
+  /**
    * Returns the available options for the 'execute_on' input parameters
    * @return A MooseEnum with the available 'execute_on' options, the default is 'residual'
    */

--- a/framework/include/executioners/EigenExecutionerBase.h
+++ b/framework/include/executioners/EigenExecutionerBase.h
@@ -135,15 +135,15 @@ protected:
   // postprocessor for eigenvalue
   const Real & _source_integral;
   const Real & _source_integral_old;
-  std::vector<ExecFlagType> _bx_execflag;
+  ExecFlagType _bx_execflag;
 
   // postprocessor for evaluating |x-xprevious|
   Real * _solution_diff;
-  std::vector<ExecFlagType> _xdiff_execflag;
+  ExecFlagType _xdiff_execflag;
 
   // postprocessor for normalization
   Real & _normalization;
-  std::vector<ExecFlagType> _norm_execflag;
+  ExecFlagType _norm_execflag;
 
   // Chebyshev acceleration
   class Chebyshev_Parameters

--- a/framework/src/base/SetupInterface.C
+++ b/framework/src/base/SetupInterface.C
@@ -67,6 +67,16 @@ SetupInterface::execFlags() const
   return _exec_flags;
 }
 
+ExecFlagType
+SetupInterface::execBitFlags() const
+{
+  unsigned char exec_bit_field = EXEC_NONE;
+  for (unsigned int i=0; i<_exec_flags.size(); ++i)
+    exec_bit_field |= _exec_flags[i];
+
+  return static_cast<ExecFlagType>(exec_bit_field);
+}
+
 MultiMooseEnum
 SetupInterface::getExecuteOptions()
 {


### PR DESCRIPTION
closes #4316

I added another method to SetupInterface to return a bit field instead of a vector.  These are handy for checking existance or one or more flags and other quick operations.
